### PR TITLE
Adds QR, more general than LinearAlgebra.QR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - 1.2  

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MatrixFactorizations"
 uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
-version = "0.1"
+version = "0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -8,4 +8,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: 1.1
   - julia_version: 1.2    

--- a/src/MatrixFactorizations.jl
+++ b/src/MatrixFactorizations.jl
@@ -8,7 +8,7 @@ import LinearAlgebra.LAPACK: liblapack, chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
             qr, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular,
             chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet,
-            QRPackedQ, AbstractQ, _zeros, _cut_B, _ret_size
+            AbstractQ, _zeros, _cut_B, _ret_size
 
 import Base: getindex, setindex!, *, +, -, ==, <, <=, >,
                 >=, /, ^, \, transpose, showerror, reindex, checkbounds, @propagate_inbounds
@@ -29,7 +29,7 @@ else
     import Base: require_one_based_indexing    
 end                            
 
-export ql, ql!, QL                        
+export ql, ql!, qrunblocked, qrunblocked!, QL                        
 
 # Elementary reflection similar to LAPACK. The reflector is not Hermitian but
 # ensures that tridiagonalization of Hermitian matrices become real. See lawn72
@@ -84,7 +84,7 @@ end
     return A
 end
 
-
+include("qr.jl")
 include("ql.jl")
 
 end #module

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -46,9 +46,10 @@ struct QR{T,S<:AbstractMatrix{T},Tau<:AbstractVector{T}} <: Factorization{T}
     end
 end
 QR(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T} = QR{T,typeof(factors), typeof(τ)}(factors, τ)
-function QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
+QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T} =
     QR(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ))
-end
+
+QR(F::LinearAlgebra.QR) = QR(F.factors, F.τ)
 
 # iteration for destructuring into components
 Base.iterate(S::QR) = (S.Q, Val(:R))
@@ -155,6 +156,8 @@ function QRPackedQ{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
 end
 
 QRPackedQ{T}(Q::QRPackedQ) where {T} = QRPackedQ(convert(AbstractMatrix{T}, Q.factors), convert(AbstractVector{T}, Q.τ))
+QRPackedQ(Q::LinearAlgebra.QRPackedQ) = QRPackedQ(Q.factors, Q.τ)
+
 AbstractMatrix{T}(Q::QRPackedQ{T}) where {T} = Q
 AbstractMatrix{T}(Q::QRPackedQ) where {T} = QRPackedQ{T}(Q)
 

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -1,0 +1,374 @@
+# This file is based on a part of Julia. License is MIT: https://julialang.org/license
+
+# It has modified the definition of QR to support general τ
+
+# QR and Hessenberg Factorizations
+"""
+    QR <: Factorization
+
+A QR matrix factorization stored in a packed format, typically obtained from
+[`qr`](@ref). If ``A`` is an `m`×`n` matrix, then
+
+```math
+A = Q R
+```
+
+where ``Q`` is an orthogonal/unitary matrix and ``R`` is upper triangular.
+The matrix ``Q`` is stored as a sequence of Householder reflectors ``v_i``
+and coefficients ``\\tau_i`` where:
+
+```math
+Q = \\prod_{i=1}^{\\min(m,n)} (I - \\tau_i v_i v_i^T).
+```
+
+Iterating the decomposition produces the components `Q` and `R`.
+
+The object has two fields:
+
+* `factors` is an `m`×`n` matrix.
+
+  - The upper triangular part contains the elements of ``R``, that is `R =
+    triu(F.factors)` for a `QR` object `F`.
+
+  - The subdiagonal part contains the reflectors ``v_i`` stored in a packed format where
+    ``v_i`` is the ``i``th column of the matrix `V = I + tril(F.factors, -1)`.
+
+* `τ` is a vector  of length `min(m,n)` containing the coefficients ``\tau_i``.
+
+"""
+struct QR{T,S<:AbstractMatrix{T},Tau<:AbstractVector{T}} <: Factorization{T}
+    factors::S
+    τ::Tau
+
+    function QR{T,S,Tau}(factors, τ) where {T,S<:AbstractMatrix{T},Tau<:AbstractVector{T}}
+        require_one_based_indexing(factors)
+        new{T,S,Tau}(factors, τ)
+    end
+end
+QR(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T} = QR{T,typeof(factors), typeof(τ)}(factors, τ)
+function QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
+    QR(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ))
+end
+
+# iteration for destructuring into components
+Base.iterate(S::QR) = (S.Q, Val(:R))
+Base.iterate(S::QR, ::Val{:R}) = (S.R, Val(:done))
+Base.iterate(S::QR, ::Val{:done}) = nothing
+
+
+function generic_qrfactUnblocked!(A::AbstractMatrix{T}) where {T}
+    require_one_based_indexing(A)
+    m, n = size(A)
+    τ = zeros(T, min(m,n))
+    for k = 1:min(m - 1 + !(T<:Real), n)
+        x = view(A, k:m, k)
+        τk = reflector!(x)
+        τ[k] = τk
+        reflectorApply!(x, τk, view(A, k:m, k + 1:n))
+    end
+    QR(A, τ)
+end
+
+qrfactUnblocked!(A::AbstractMatrix) = generic_qrfactUnblocked!(A)
+qrfactUnblocked!(A::StridedMatrix{T}) where T<:BlasFloat = QR(LAPACK.geqrf!(A)...)
+
+qrunblocked!(A::AbstractMatrix, ::Val{false}) = qrfactUnblocked!(A)
+qrunblocked!(A::AbstractMatrix) = qrunblocked!(A, Val(false))
+
+_qreltype(::Type{T}) where T = typeof(zero(T)/sqrt(abs2(one(T))))
+
+
+function qrunblocked(A::AbstractMatrix{T}, arg) where T
+    require_one_based_indexing(A)
+    AA = similar(A, _qleltype(T), size(A))
+    copyto!(AA, A)
+    return qrunblocked!(AA, arg)
+end
+function qrunblocked(A::AbstractMatrix{T}) where T
+    require_one_based_indexing(A)
+    AA = similar(A, _qleltype(T), size(A))
+    copyto!(AA, A)
+    return qrunblocked!(AA)
+end
+qrunblocked(x::Number) = qrunblocked(fill(x,1,1))
+function qrunblocked(v::AbstractVector)
+    require_one_based_indexing(v)
+    qrunblocked(reshape(v, (length(v), 1)))
+end
+
+# Conversions
+QR{T}(A::QR) where {T} = QR(convert(AbstractMatrix{T}, A.factors), convert(AbstractVector{T}, A.τ))
+Factorization{T}(A::QR{T}) where {T} = A
+Factorization{T}(A::QR) where {T} = QR{T}(A)
+AbstractMatrix(F::QR) = F.Q * F.R
+AbstractArray(F::QR) = AbstractMatrix(F)
+Matrix(F::QR) = Array(AbstractArray(F))
+Array(F::QR) = Matrix(F)
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::QR)
+    summary(io, F); println(io)
+    println(io, "Q factor:")
+    show(io, mime, F.Q)
+    println(io, "\nR factor:")
+    show(io, mime, F.R)
+end
+
+@inline function getR(F::QR, _) 
+    m, n = size(F)
+    triu!(getfield(F, :factors)[1:min(m,n), 1:n])
+end
+@inline getQ(F::QR, _) = QRPackedQ(getfield(F, :factors), F.τ)
+
+getR(F::QR) = getR(F, axes(F.factors))
+getQ(F::QR) = getQ(F, axes(F.factors))
+
+function getproperty(F::QR, d::Symbol)
+    if d == :R
+        return getR(F)
+    elseif d == :Q
+        return getQ(F)
+    else
+        getfield(F, d)
+    end
+end
+
+Base.propertynames(F::QR, private::Bool=false) =
+    (:R, :Q, (private ? fieldnames(typeof(F)) : ())...)
+
+"""
+    QRPackedQ <: AbstractMatrix
+
+The orthogonal/unitary ``Q`` matrix of a QR factorization stored in [`QR`](@ref).
+"""
+struct QRPackedQ{T,S<:AbstractMatrix{T},Tau<:AbstractVector{T}} <: AbstractQ{T}
+    factors::S
+    τ::Tau
+
+    function QRPackedQ{T,S,Tau}(factors, τ) where {T,S<:AbstractMatrix{T},Tau<:AbstractVector{T}}
+        require_one_based_indexing(factors)
+        new{T,S,Tau}(factors, τ)
+    end
+end
+QRPackedQ(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T} = QRPackedQ{T,typeof(factors),typeof(τ)}(factors, τ)
+function QRPackedQ{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
+    QRPackedQ(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ))
+end
+
+QRPackedQ{T}(Q::QRPackedQ) where {T} = QRPackedQ(convert(AbstractMatrix{T}, Q.factors), convert(AbstractVector{T}, Q.τ))
+AbstractMatrix{T}(Q::QRPackedQ{T}) where {T} = Q
+AbstractMatrix{T}(Q::QRPackedQ) where {T} = QRPackedQ{T}(Q)
+
+
+size(F::QR, dim::Integer) = size(getfield(F, :factors), dim)
+size(F::QR) = size(getfield(F, :factors))
+
+
+## Multiplication by Q
+### QB
+lmul!(A::QRPackedQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:StridedMatrix} =
+    LAPACK.ormqr!('L','N',A.factors,A.τ,B)
+
+function lmul!(A::QRPackedQ, B::AbstractVecOrMat)
+    require_one_based_indexing(B)
+    mA, nA = size(A.factors)
+    mB, nB = size(B,1), size(B,2)
+    if mA != mB
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
+    end
+    Afactors = A.factors
+    @inbounds begin
+        for k = min(mA,nA):-1:1
+            for j = 1:nB
+                vBj = B[k,j]
+                for i = k+1:mB
+                    vBj += conj(Afactors[i,k])*B[i,j]
+                end
+                vBj = A.τ[k]*vBj
+                B[k,j] -= vBj
+                for i = k+1:mB
+                    B[i,j] -= Afactors[i,k]*vBj
+                end
+            end
+        end
+    end
+    B
+end
+
+### QcB
+lmul!(adjA::Adjoint{<:Any,<:QRPackedQ{T,S,Vector{T}}}, B::StridedVecOrMat{T}) where {T<:BlasReal,S<:StridedMatrix} =
+    (A = adjA.parent; LAPACK.ormqr!('L','T',A.factors,A.τ,B))
+lmul!(adjA::Adjoint{<:Any,<:QRPackedQ{T,S,Vector{T}}}, B::StridedVecOrMat{T}) where {T<:BlasComplex,S<:StridedMatrix} =
+    (A = adjA.parent; LAPACK.ormqr!('L','C',A.factors,A.τ,B))
+function lmul!(adjA::Adjoint{<:Any,<:QRPackedQ}, B::AbstractVecOrMat)
+    require_one_based_indexing(B)
+    A = adjA.parent
+    mA, nA = size(A.factors)
+    mB, nB = size(B,1), size(B,2)
+    if mA != mB
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
+    end
+    Afactors = A.factors
+    @inbounds begin
+        for k = 1:min(mA,nA)
+            for j = 1:nB
+                vBj = B[k,j]
+                for i = k+1:mB
+                    vBj += conj(Afactors[i,k])*B[i,j]
+                end
+                vBj = conj(A.τ[k])*vBj
+                B[k,j] -= vBj
+                for i = k+1:mB
+                    B[i,j] -= Afactors[i,k]*vBj
+                end
+            end
+        end
+    end
+    B
+end
+
+## AQ
+rmul!(A::StridedVecOrMat{T}, B::QRPackedQ{T,S,Vector{T}}) where {T<:BlasFloat,S<:StridedMatrix} =
+    LAPACK.ormqr!('R', 'N', B.factors, B.τ, A)
+function rmul!(A::AbstractMatrix,Q::QRPackedQ)
+    mQ, nQ = size(Q.factors)
+    mA, nA = size(A,1), size(A,2)
+    if nA != mQ
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
+    end
+    Qfactors = Q.factors
+    @inbounds begin
+        for k = 1:min(mQ,nQ)
+            for i = 1:mA
+                vAi = A[i,k]
+                for j = k+1:mQ
+                    vAi += A[i,j]*Qfactors[j,k]
+                end
+                vAi = vAi*Q.τ[k]
+                A[i,k] -= vAi
+                for j = k+1:nA
+                    A[i,j] -= vAi*conj(Qfactors[j,k])
+                end
+            end
+        end
+    end
+    A
+end
+
+### AQc
+rmul!(A::StridedVecOrMat{T}, adjB::Adjoint{<:Any,<:QRPackedQ{T,S,Vector{T}}}) where {T<:BlasReal,S<:StridedMatrix} =
+    (B = adjB.parent; LAPACK.ormqr!('R','T',B.factors,B.τ,A))
+rmul!(A::StridedVecOrMat{T}, adjB::Adjoint{<:Any,<:QRPackedQ{T,S,Vector{T}}}) where {T<:BlasComplex,S<:StridedMatrix} =
+    (B = adjB.parent; LAPACK.ormqr!('R','C',B.factors,B.τ,A))
+function rmul!(A::AbstractMatrix, adjQ::Adjoint{<:Any,<:QRPackedQ})
+    Q = adjQ.parent
+    mQ, nQ = size(Q.factors)
+    mA, nA = size(A,1), size(A,2)
+    if nA != mQ
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
+    end
+    Qfactors = Q.factors
+    @inbounds begin
+        for k = min(mQ,nQ):-1:1
+            for i = 1:mA
+                vAi = A[i,k]
+                for j = k+1:mQ
+                    vAi += A[i,j]*Qfactors[j,k]
+                end
+                vAi = vAi*conj(Q.τ[k])
+                A[i,k] -= vAi
+                for j = k+1:nA
+                    A[i,j] -= vAi*conj(Qfactors[j,k])
+                end
+            end
+        end
+    end
+    A
+end
+
+# Julia implementation similar to xgelsy
+function ldiv!(A::QR{T}, B::AbstractMatrix{T}) where T
+    m, n = size(A)
+    minmn = min(m,n)
+    mB, nB = size(B)
+    lmul!(adjoint(A.Q), view(B, 1:m, :))
+    R = A.R
+    @inbounds begin
+        if n > m # minimum norm solution
+            τ = zeros(T,m)
+            for k = m:-1:1 # Trapezoid to triangular by elementary operation
+                x = view(R, k, [k; m + 1:n])
+                τk = reflector!(x)
+                τ[k] = conj(τk)
+                for i = 1:k - 1
+                    vRi = R[i,k]
+                    for j = m + 1:n
+                        vRi += R[i,j]*x[j - m + 1]'
+                    end
+                    vRi *= τk
+                    R[i,k] -= vRi
+                    for j = m + 1:n
+                        R[i,j] -= vRi*x[j - m + 1]
+                    end
+                end
+            end
+        end
+        LinearAlgebra.ldiv!(UpperTriangular(view(R, :, 1:minmn)), view(B, 1:minmn, :))
+        if n > m # Apply elementary transformation to solution
+            B[m + 1:mB,1:nB] .= zero(T)
+            for j = 1:nB
+                for k = 1:m
+                    vBj = B[k,j]
+                    for i = m + 1:n
+                        vBj += B[i,j]*R[k,i]'
+                    end
+                    vBj *= τ[k]
+                    B[k,j] -= vBj
+                    for i = m + 1:n
+                        B[i,j] -= R[k,i]*vBj
+                    end
+                end
+            end
+        end
+    end
+    return B
+end
+ldiv!(A::QR, B::AbstractVector) = ldiv!(A, reshape(B, length(B), 1))[:]
+
+
+function (\)(A::QR{TA}, B::AbstractVecOrMat{TB}) where {TA,TB}
+    require_one_based_indexing(B)
+    S = promote_type(TA,TB)
+    m, n = size(A)
+    m == size(B,1) || throw(DimensionMismatch("Both inputs should have the same number of rows"))
+
+    AA = Factorization{S}(A)
+
+    X = _zeros(S, B, n)
+    X[1:size(B, 1), :] = B
+    ldiv!(AA, X)
+    return _cut_B(X, 1:n)
+end
+
+function (\)(A::QR{T}, BIn::VecOrMat{Complex{T}}) where T<:BlasReal
+    require_one_based_indexing(BIn)
+    m, n = size(A)
+    m == size(BIn, 1) || throw(DimensionMismatch("left hand side has $m rows, but right hand side has $(size(BIn,1)) rows"))
+
+# |z1|z3|  reinterpret  |x1|x2|x3|x4|  transpose  |x1|y1|  reshape  |x1|y1|x3|y3|
+# |z2|z4|      ->       |y1|y2|y3|y4|     ->      |x2|y2|     ->    |x2|y2|x4|y4|
+#                                                 |x3|y3|
+#                                                 |x4|y4|
+    B = reshape(copy(transpose(reinterpret(T, reshape(BIn, (1, length(BIn)))))), size(BIn, 1), 2*size(BIn, 2))
+
+    X = _zeros(T, B, n)
+    X[1:size(B, 1), :] = B
+
+    ldiv!(A, X)
+
+# |z1|z3|  reinterpret  |x1|x2|x3|x4|  transpose  |x1|y1|  reshape  |x1|y1|x3|y3|
+# |z2|z4|      <-       |y1|y2|y3|y4|     <-      |x2|y2|     <-    |x2|y2|x4|y4|
+#                                                 |x3|y3|
+#                                                 |x4|y4|
+    XX = reshape(collect(reinterpret(Complex{T}, copy(transpose(reshape(X, div(length(X), 2), 2))))), _ret_size(A, BIn))
+    return _cut_B(XX, 1:n)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,188 +20,276 @@ bimg  = randn(n,2)/2
 squareQ(Q::LinearAlgebra.AbstractQ) = (sq = size(Q.factors, 1); lmul!(Q, Matrix{eltype(Q)}(I, sq, sq)))
 rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
 
-@testset "Compare with QR" begin
-    n = 10
-    A = randn(n,n)
-    Q̃, R = qr(A[end:-1:1,end:-1:1])
-    Q, L = ql(A)
-    Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
-    @test Q.factors ≈ Q̄.factors
-    @test Q.τ ≈ Q̄.τ
-    @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
-    @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
+@testset "QR" begin
+    @testset for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
+        raw_a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
+        raw_a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(a2real, a2img) : a2real)
+        asym = raw_a' + raw_a                  # symmetric indefinite
+        apd  = raw_a' * raw_a                 # symmetric positive-definite
+        ε = εa = eps(abs(float(one(eltya))))
 
-    A = randn(n,n+2)
-    Q̃, R = qr(A[end:-1:1,end:-1:1])
-    Q, L = ql(A)
-    Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
-    @test Q.factors ≈ Q̄.factors
-    @test Q.τ ≈ Q̄.τ
-    @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
-    @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
+        @testset for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
+            raw_b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
+            εb = eps(abs(float(one(eltyb))))
+            ε = max(εa, εb)
+            tab = promote_type(eltya, eltyb)
 
-    A = randn(n+2,n)
-    Q̃, R = qr(A[end:-1:1,end:-1:1])
-    Q, L = ql(A)
-    Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
-    @test Q.factors ≈ Q̄.factors
-    @test Q.τ ≈ Q̄.τ
-    @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
-    @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
-end
-
-@testset for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
-    raw_a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
-    raw_a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(a2real, a2img) : a2real)
-    asym = raw_a' + raw_a                  # symmetric indefinite
-    apd  = raw_a' * raw_a                 # symmetric positive-definite
-    ε = εa = eps(abs(float(one(eltya))))
-
-    @testset for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
-        raw_b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
-        εb = eps(abs(float(one(eltyb))))
-        ε = max(εa, εb)
-        tab = promote_type(eltya, eltyb)
-
-        @testset "QL decomposition of a Number" begin
-            α = rand(eltyb)
-            aα = fill(α, 1, 1)
-            @test ql(α).Q * ql(α).L ≈ ql(aα).Q * ql(aα).L
-            @test abs(ql(α).Q[1,1]) ≈ one(eltyb)
-        end
-
-        for (a, b) in ((raw_a, raw_b),
-               (view(raw_a, 1:n-1, 1:n-1), view(raw_b, 1:n-1, 1)))
-            a_1 = size(a, 1)
-            @testset "QL decomposition (without pivoting)" begin
-                qla   = @inferred ql(a)
-                @inferred ql(a)
-                q, l  = qla.Q, qla.L
-                @test_throws ErrorException qla.Z
-                @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
-                @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
-                @test q'*Matrix(1.0I, a_1, a_1)' ≈ squareQ(q)'
-                @test squareQ(q)'q ≈ Matrix(I, a_1, a_1)
-                @test Matrix(1.0I, a_1, a_1)'q' ≈ squareQ(q)'
-                @test q*l ≈ a
-                @test a*(qla\b) ≈ b atol=3000ε
-                @test Array(qla) ≈ a
-                sq = size(q.factors, 2)
-                @test *(Matrix{eltyb}(I, sq, sq), adjoint(q)) * squareQ(q) ≈ Matrix(I, sq, sq) atol=5000ε
-                if eltya != Int
-                    @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab}, q)
-                    ac = copy(a)
-                    @test ql!(a[:, 1:5])\b == ql!(view(ac, :, 1:5))\b
-                end
-                qlstring = sprint((t, s) -> show(t, "text/plain", s), qla)
-                rstring  = sprint((t, s) -> show(t, "text/plain", s), l)
-                qstring  = sprint((t, s) -> show(t, "text/plain", s), q)
-                @test qlstring == "$(summary(qla))\nQ factor:\n$qstring\nL factor:\n$rstring"
+            @testset "QR decomposition of a Number" begin
+                α = rand(eltyb)
+                aα = fill(α, 1, 1)
+                @test qrunblocked(α).Q * qrunblocked(α).R ≈ qrunblocked(aα).Q * qrunblocked(aα).R
+                @test abs(qrunblocked(α).Q[1,1]) ≈ one(eltyb)
             end
-            @testset "Thin QL decomposition (without pivoting)" begin
-                qla   = @inferred ql(a[:, 1:n1], Val(false))
-                @inferred ql(a[:, 1:n1], Val(false))
-                q,l   = qla.Q, qla.L
-                @test_throws ErrorException qla.Z
-                @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
-                @test q'*rectangularQ(q) ≈ Matrix(I, a_1, n1)
-                @test q*l ≈ a[:, 1:n1]
-                @test q*b[1:n1] ≈ rectangularQ(q)*b[1:n1] atol=100ε
-                @test q*b ≈ squareQ(q)*b atol=100ε
-                @test_throws DimensionMismatch q*b[1:n1 + 1]
-                @test_throws DimensionMismatch b[1:n1 + 1]*q'
-                sq = size(q.factors, 1)
-                @test *(LowerTriangular(Matrix{eltyb}(I, sq, sq)), adjoint(q))*squareQ(q) ≈ Matrix(I, a_1, a_1) atol=5000ε
-                if eltya != Int
-                    @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab},q)
+
+            for (a, b) in ((raw_a, raw_b),
+                (view(raw_a, 1:n-1, 1:n-1), view(raw_b, 1:n-1, 1)))
+                a_1 = size(a, 1)
+                @testset "QR decomposition (without pivoting)" begin
+                    qra   = @inferred qrunblocked(a)
+                    @inferred qrunblocked(a)
+                    q, r = qra.Q, qra.R
+                    @test_throws ErrorException qra.Z
+                    @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
+                    @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
+                    @test q'*Matrix(1.0I, a_1, a_1)' ≈ squareQ(q)'
+                    @test squareQ(q)'q ≈ Matrix(I, a_1, a_1)
+                    @test Matrix(1.0I, a_1, a_1)'q' ≈ squareQ(q)'
+                    @test q*r ≈ a
+                    @test a*(qra\b) ≈ b atol=3000ε
+                    @test Array(qra) ≈ a
+                    sq = size(q.factors, 2)
+                    @test *(Matrix{eltyb}(I, sq, sq), adjoint(q)) * squareQ(q) ≈ Matrix(I, sq, sq) atol=5000ε
+                    if eltya != Int
+                        @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab}, q)
+                        ac = copy(a)
+                        @test qrunblocked!(a[:, 1:5])\b == qrunblocked!(view(ac, :, 1:5))\b
+                    end
+                    qrstring = sprint((t, s) -> show(t, "text/plain", s), qra)
+                    rstring  = sprint((t, s) -> show(t, "text/plain", s), r)
+                    qstring  = sprint((t, s) -> show(t, "text/plain", s), q)
+                    @test qrstring == "$(summary(qra))\nQ factor:\n$qstring\nR factor:\n$rstring"
+                end
+                @testset "Thin QR decomposition (without pivoting)" begin
+                    qra   = @inferred qrunblocked(a[:, 1:n1], Val(false))
+                    @inferred qrunblocked(a[:, 1:n1], Val(false))
+                    q,r   = qra.Q, qra.R
+                    @test_throws ErrorException qra.Z
+                    @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
+                    @test q'*rectangularQ(q) ≈ Matrix(I, a_1, n1)
+                    @test q*r ≈ a[:, 1:n1]
+                    @test q*b[1:n1] ≈ rectangularQ(q)*b[1:n1] atol=100ε
+                    @test q*b ≈ squareQ(q)*b atol=100ε
+                    @test_throws DimensionMismatch q*b[1:n1 + 1]
+                    @test_throws DimensionMismatch b[1:n1 + 1]*q'
+                    sq = size(q.factors, 1)
+                    @test *(LowerTriangular(Matrix{eltyb}(I, sq, sq)), adjoint(q))*squareQ(q) ≈ Matrix(I, a_1, a_1) atol=5000ε
+                    if eltya != Int
+                        @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab},q)
+                    end
+                end
+            end
+            if eltya != Int
+                @testset "Matmul with QR factorizations" begin
+                    a = raw_a
+
+                    qra = qrunblocked(a[:,1:n1], Val(false))
+                    q, r = qra.Q, qra.R
+                    @test rmul!(copy(squareQ(q)'), q) ≈ Matrix(I, n, n)
+                    @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
+                    @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
+                    @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
+                    @test_throws ErrorException size(q,-1)
+                    @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
                 end
             end
         end
-        if eltya != Int
-            @testset "Matmul with QL factorizations" begin
-                a = raw_a
+    end 
+end
 
-                qla = ql(a[:,1:n1], Val(false))
-                q, l = qla.Q, qla.L
-                @test rmul!(copy(squareQ(q)'), q) ≈ Matrix(I, n, n)
-                @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
-                @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
-                @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
-                @test_throws ErrorException size(q,-1)
-                @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
+@testset "QL" begin
+    @testset "Compare with QR" begin
+        n = 10
+        A = randn(n,n)
+        Q̃, R = qr(A[end:-1:1,end:-1:1])
+        Q, L = ql(A)
+        Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
+        @test Q.factors ≈ Q̄.factors
+        @test Q.τ ≈ Q̄.τ
+        @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
+        @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
+
+        A = randn(n,n+2)
+        Q̃, R = qr(A[end:-1:1,end:-1:1])
+        Q, L = ql(A)
+        Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
+        @test Q.factors ≈ Q̄.factors
+        @test Q.τ ≈ Q̄.τ
+        @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
+        @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
+
+        A = randn(n+2,n)
+        Q̃, R = qr(A[end:-1:1,end:-1:1])
+        Q, L = ql(A)
+        Q̄, L̄ = MatrixFactorizations.generic_qlfactUnblocked!(copy(A))
+        @test Q.factors ≈ Q̄.factors
+        @test Q.τ ≈ Q̄.τ
+        @test R[end:-1:1,end:-1:1] ≈ L ≈ L̄
+        @test Q̃[end:-1:1,end:-1:1] ≈ Q ≈ Q̄
+    end
+
+    @testset for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
+        raw_a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
+        raw_a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(a2real, a2img) : a2real)
+        asym = raw_a' + raw_a                  # symmetric indefinite
+        apd  = raw_a' * raw_a                 # symmetric positive-definite
+        ε = εa = eps(abs(float(one(eltya))))
+
+        @testset for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
+            raw_b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
+            εb = eps(abs(float(one(eltyb))))
+            ε = max(εa, εb)
+            tab = promote_type(eltya, eltyb)
+
+            @testset "QL decomposition of a Number" begin
+                α = rand(eltyb)
+                aα = fill(α, 1, 1)
+                @test ql(α).Q * ql(α).L ≈ ql(aα).Q * ql(aα).L
+                @test abs(ql(α).Q[1,1]) ≈ one(eltyb)
+            end
+
+            for (a, b) in ((raw_a, raw_b),
+                (view(raw_a, 1:n-1, 1:n-1), view(raw_b, 1:n-1, 1)))
+                a_1 = size(a, 1)
+                @testset "QL decomposition (without pivoting)" begin
+                    qla   = @inferred ql(a)
+                    @inferred ql(a)
+                    q, l  = qla.Q, qla.L
+                    @test_throws ErrorException qla.Z
+                    @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
+                    @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
+                    @test q'*Matrix(1.0I, a_1, a_1)' ≈ squareQ(q)'
+                    @test squareQ(q)'q ≈ Matrix(I, a_1, a_1)
+                    @test Matrix(1.0I, a_1, a_1)'q' ≈ squareQ(q)'
+                    @test q*l ≈ a
+                    @test a*(qla\b) ≈ b atol=3000ε
+                    @test Array(qla) ≈ a
+                    sq = size(q.factors, 2)
+                    @test *(Matrix{eltyb}(I, sq, sq), adjoint(q)) * squareQ(q) ≈ Matrix(I, sq, sq) atol=5000ε
+                    if eltya != Int
+                        @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab}, q)
+                        ac = copy(a)
+                        @test ql!(a[:, 1:5])\b == ql!(view(ac, :, 1:5))\b
+                    end
+                    qlstring = sprint((t, s) -> show(t, "text/plain", s), qla)
+                    rstring  = sprint((t, s) -> show(t, "text/plain", s), l)
+                    qstring  = sprint((t, s) -> show(t, "text/plain", s), q)
+                    @test qlstring == "$(summary(qla))\nQ factor:\n$qstring\nL factor:\n$rstring"
+                end
+                @testset "Thin QL decomposition (without pivoting)" begin
+                    qla   = @inferred ql(a[:, 1:n1], Val(false))
+                    @inferred ql(a[:, 1:n1], Val(false))
+                    q,l   = qla.Q, qla.L
+                    @test_throws ErrorException qla.Z
+                    @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
+                    @test q'*rectangularQ(q) ≈ Matrix(I, a_1, n1)
+                    @test q*l ≈ a[:, 1:n1]
+                    @test q*b[1:n1] ≈ rectangularQ(q)*b[1:n1] atol=100ε
+                    @test q*b ≈ squareQ(q)*b atol=100ε
+                    @test_throws DimensionMismatch q*b[1:n1 + 1]
+                    @test_throws DimensionMismatch b[1:n1 + 1]*q'
+                    sq = size(q.factors, 1)
+                    @test *(LowerTriangular(Matrix{eltyb}(I, sq, sq)), adjoint(q))*squareQ(q) ≈ Matrix(I, a_1, a_1) atol=5000ε
+                    if eltya != Int
+                        @test Matrix{eltyb}(I, a_1, a_1)*q ≈ convert(AbstractMatrix{tab},q)
+                    end
+                end
+            end
+            if eltya != Int
+                @testset "Matmul with QL factorizations" begin
+                    a = raw_a
+
+                    qla = ql(a[:,1:n1], Val(false))
+                    q, l = qla.Q, qla.L
+                    @test rmul!(copy(squareQ(q)'), q) ≈ Matrix(I, n, n)
+                    @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
+                    @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
+                    @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
+                    @test_throws ErrorException size(q,-1)
+                    @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
+                end
             end
         end
     end
-end
 
-@testset "transpose errors" begin
-    @test_throws MethodError transpose(ql(randn(3,3)))
-    @test_throws MethodError adjoint(ql(randn(3,3)))
-    @test_throws MethodError transpose(ql(randn(3,3), Val(false)))
-    @test_throws MethodError adjoint(ql(randn(3,3), Val(false)))
-    @test_throws MethodError transpose(ql(big.(randn(3,3))))
-    @test_throws MethodError adjoint(ql(big.(randn(3,3))))
-end
+    @testset "transpose errors" begin
+        @test_throws MethodError transpose(ql(randn(3,3)))
+        @test_throws MethodError adjoint(ql(randn(3,3)))
+        @test_throws MethodError transpose(ql(randn(3,3), Val(false)))
+        @test_throws MethodError adjoint(ql(randn(3,3), Val(false)))
+        @test_throws MethodError transpose(ql(big.(randn(3,3))))
+        @test_throws MethodError adjoint(ql(big.(randn(3,3))))
+    end
 
-@testset "Issue 7304" begin
-    A = [-√.5 -√.5; -√.5 √.5]
-    Q = rectangularQ(ql(A).Q)
-    @test norm(A+Q) < eps()
-end
+    @testset "Issue 7304" begin
+        A = [-√.5 -√.5; -√.5 √.5]
+        Q = rectangularQ(ql(A).Q)
+        @test norm(A+Q) < eps()
+    end
 
-@testset "ql on AbstractVector" begin
-    vl = [3.0, 4.0]
-    for Tl in (Float32, Float64)
-        for T in (Tl, Complex{Tl})
-            v = convert(Vector{T}, vl)
-            nv, nm = ql(v)
-            @test nv*nm ≈ v
+    @testset "ql on AbstractVector" begin
+        vl = [3.0, 4.0]
+        for Tl in (Float32, Float64)
+            for T in (Tl, Complex{Tl})
+                v = convert(Vector{T}, vl)
+                nv, nm = ql(v)
+                @test nv*nm ≈ v
+            end
         end
     end
-end
 
-@testset "Issue 24589. Promotion of rational matrices" begin
-    A = rand(1//1:5//5, 4,3)
-    @test first(ql(A)) == first(ql(float(A)))
-end
+    @testset "Issue 24589. Promotion of rational matrices" begin
+        A = rand(1//1:5//5, 4,3)
+        @test first(ql(A)) == first(ql(float(A)))
+    end
 
-@testset "Issue Test Factorization fallbacks for rectangular problems" begin
-    A  = randn(3,2)
-    Ac = copy(A')
-    b  = randn(3)
-    b0 = copy(b)
-    c  = randn(2)
-    @test_broken A \b ≈ ldiv!(c, ql(A ), b)
-end
+    @testset "Issue Test Factorization fallbacks for rectangular problems" begin
+        A  = randn(3,2)
+        Ac = copy(A')
+        b  = randn(3)
+        b0 = copy(b)
+        c  = randn(2)
+        @test_broken A \b ≈ ldiv!(c, ql(A ), b)
+    end
 
-@testset "Wide QL" begin
-    A = randn(3,5)
-    Q,L = ql(A)
-    @test Q*L ≈ A
-end
+    @testset "Wide QL" begin
+        A = randn(3,5)
+        Q,L = ql(A)
+        @test Q*L ≈ A
+    end
 
-@testset "lmul!/rmul!" begin
-    A = randn(100,100)
-    Q,L = ql(A)
-    x = randn(100)
-    b = randn(100,2)
-    @test lmul!(Q, copy(x)) ≈ Matrix(Q)*x
-    @test lmul!(Q, copy(b)) ≈ Matrix(Q)*b
-    @test lmul!(Q', copy(x)) ≈ Matrix(Q)'*x
-    @test lmul!(Q', copy(b)) ≈ Matrix(Q)'*b
-    c = randn(2,100)
-    @test rmul!(copy(c), Q) ≈ c*Matrix(Q)
-    @test rmul!(copy(c), Q') ≈ c*Matrix(Q')
+    @testset "lmul!/rmul!" begin
+        A = randn(100,100)
+        Q,L = ql(A)
+        x = randn(100)
+        b = randn(100,2)
+        @test lmul!(Q, copy(x)) ≈ Matrix(Q)*x
+        @test lmul!(Q, copy(b)) ≈ Matrix(Q)*b
+        @test lmul!(Q', copy(x)) ≈ Matrix(Q)'*x
+        @test lmul!(Q', copy(b)) ≈ Matrix(Q)'*b
+        c = randn(2,100)
+        @test rmul!(copy(c), Q) ≈ c*Matrix(Q)
+        @test rmul!(copy(c), Q') ≈ c*Matrix(Q')
 
-    A = randn(100,103)
-    Q,L = ql(A)
-    x = randn(100)
-    b = randn(100,2)
-    @test lmul!(Q, copy(x)) ≈ Matrix(Q)*x
-    @test lmul!(Q, copy(b)) ≈ Matrix(Q)*b
-    @test lmul!(Q', copy(x)) ≈ Matrix(Q)'*x
-    @test lmul!(Q', copy(b)) ≈ Matrix(Q)'*b
-    c = randn(2,100)
-    @test rmul!(copy(c), Q) ≈ c*Matrix(Q)
-    @test rmul!(copy(c), Q') ≈ c*Matrix(Q')
+        A = randn(100,103)
+        Q,L = ql(A)
+        x = randn(100)
+        b = randn(100,2)
+        @test lmul!(Q, copy(x)) ≈ Matrix(Q)*x
+        @test lmul!(Q, copy(b)) ≈ Matrix(Q)*b
+        @test lmul!(Q', copy(x)) ≈ Matrix(Q)'*x
+        @test lmul!(Q', copy(b)) ≈ Matrix(Q)'*b
+        c = randn(2,100)
+        @test rmul!(copy(c), Q) ≈ c*Matrix(Q)
+        @test rmul!(copy(c), Q') ≈ c*Matrix(Q')
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,11 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                     @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
                     @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
                     @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
-                    @test_throws ErrorException size(q,-1)
+                    if VERSION < v"1.1-"
+                        @test_throws BoundsError size(q,-1)
+                    else
+                        @test_throws ErrorException size(q,-1)
+                    end
                     @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,16 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
         @test rmul!(copy(c), Q) ≈ c*Matrix(Q)
         @test rmul!(copy(c), Q') ≈ c*Matrix(Q')
     end
+
+    @testset "LinearAlgebra.QR -> MatrixFactorizations.QR" begin
+        A = randn(10,10)
+        F̃ = LinearAlgebra.qrfactUnblocked!(copy(A))
+        F = MatrixFactorizations.QR(F̃)
+        Q,R = F
+        @test Q*R ≈ A
+        Q̃,_ = F̃
+        @test MatrixFactorizations.QRPackedQ(Q̃)*R ≈ A
+    end
 end
 
 @testset "QL" begin


### PR DESCRIPTION
This is to allow general τ vectors. Otherwise the code is the same.

Future changes may better support sparse vectors.